### PR TITLE
:adhesive_bandage: import statements mqt.bench.utils

### DIFF
--- a/src/mqt/predictor/ml/Predictor.py
+++ b/src/mqt/predictor/ml/Predictor.py
@@ -12,7 +12,7 @@ if TYPE_CHECKING:
 import matplotlib.pyplot as plt
 import numpy as np
 from joblib import Parallel, delayed, load
-from mqt.bench.utils import qiskit_helper, tket_helper
+from mqt.bench import qiskit_helper, tket_helper
 from mqt.predictor import ml, reward, utils
 from mqt.predictor.ml import QiskitOptions, TketOptions, TrainingSample
 from pytket.extensions.qiskit import tk_to_qiskit

--- a/src/mqt/predictor/rl/Predictor.py
+++ b/src/mqt/predictor/rl/Predictor.py
@@ -17,15 +17,15 @@ from mqt.predictor.rl.helper import (
 from mqt.predictor.rl.PredictorEnv import PredictorEnv
 from mqt.predictor.rl.Result import Result
 from pytket import OpType
-from pytket.architecture import Architecture  # type: ignore[attr-defined]
+from pytket.architecture import Architecture
 from pytket.extensions.qiskit import qiskit_to_tk, tk_to_qiskit
-from pytket.passes import (  # type: ignore[attr-defined]
+from pytket.passes import (
     FullPeepholeOptimise,
     PlacementPass,
     RoutingPass,
     auto_rebase_pass,
 )
-from pytket.placement import GraphPlacement  # type: ignore[attr-defined]
+from pytket.placement import GraphPlacement
 from qiskit import QuantumCircuit, transpile
 from sb3_contrib import MaskablePPO
 from sb3_contrib.common.maskable.policies import MaskableMultiInputActorCriticPolicy

--- a/src/mqt/predictor/rl/helper.py
+++ b/src/mqt/predictor/rl/helper.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING, Callable, Literal, TypedDict
 
 if TYPE_CHECKING:
     from numpy.typing import NDArray
-    from pytket.passes import BasePass as PytketBasePass  # type: ignore[attr-defined]
+    from pytket.passes import BasePass as PytketBasePass
     from qiskit.transpiler.basepasses import BasePass as QiskitBasePass
 
 import numpy as np
@@ -21,9 +21,9 @@ from mqt.predictor.devices import (
 )
 from mqt.predictor.reward import calc_supermarq_features
 from packaging import version
-from pytket.architecture import Architecture  # type: ignore[attr-defined]
-from pytket.circuit import OpType  # type: ignore[attr-defined]
-from pytket.passes import (  # type: ignore[attr-defined]
+from pytket.architecture import Architecture
+from pytket.circuit import OpType
+from pytket.passes import (
     CliffordSimp,
     FullPeepholeOptimise,
     PeepholeOptimise2Q,

--- a/tests/ml/test_helper_ml.py
+++ b/tests/ml/test_helper_ml.py
@@ -1,8 +1,7 @@
 from pathlib import Path
 from typing import cast
 
-from mqt.bench import benchmark_generator
-from mqt.bench import qiskit_helper
+from mqt.bench import benchmark_generator, qiskit_helper
 from mqt.predictor import ml, reward
 from mqt.predictor.ml import QiskitOptions
 

--- a/tests/ml/test_helper_ml.py
+++ b/tests/ml/test_helper_ml.py
@@ -2,7 +2,7 @@ from pathlib import Path
 from typing import cast
 
 from mqt.bench import benchmark_generator
-from mqt.bench.utils import qiskit_helper
+from mqt.bench import qiskit_helper
 from mqt.predictor import ml, reward
 from mqt.predictor.ml import QiskitOptions
 


### PR DESCRIPTION
Couldn't find modules `qiskit_helper` and `tket_helper` under `mqt.bench.utils`.
They were probably moved since February.

Also I want to use this commit to create a first PR (dev guidelines stated to create (draft) PR early).