### PR TITLE
🐛 added mean errors in device calibration file

### DIFF
--- a/src/mqt/predictor/Calibration.py
+++ b/src/mqt/predictor/Calibration.py
@@ -25,6 +25,8 @@ class Calibration:
             self.ionq_harmony_calibration = parse_simple_calibration_config("ionq_harmony")
             self.ionq_aria1_calibration = parse_simple_calibration_config("ionq_aria1")
             self.quantinuum_h2_calibration = parse_simple_calibration_config("quantinuum_h2")
+            self.ibm_washington_cx_mean_error = get_mean_IBM_washington_cx_error()
+            self.ibm_montreal_cx_mean_error = get_mean_IBM_montreal_cx_error()
 
         except Exception as e:
             raise RuntimeError("Error in Calibration initialization: " + str(e)) from e


### PR DESCRIPTION
Those two introduced variables are used in `reward.py`, e.g., here: https://github.com/cda-tum/mqt-predictor/blob/d9e156866571a16bfee5ba838c0554ad039caed5/src/mqt/predictor/reward.py#L228

Apparently, those variables were not needed because currently no `error_rates==1.0` occurs. Nevertheless, I like to keep it to be save.