### PR TITLE
Integrate bench devices module

### DIFF
--- a/src/mqt/predictor/Result.py
+++ b/src/mqt/predictor/Result.py
@@ -7,6 +7,8 @@ from mqt.predictor import reward
 if TYPE_CHECKING:
     from qiskit import QuantumCircuit
 
+    from mqt.bench.devices import Device
+
 
 class Result:
     """
@@ -16,7 +18,7 @@ class Result:
         compilation_setup (str): The setup used for compilation. Either 'mqt-predictor_<figure_of_merit>', 'qiskit' or 'tket'. For the two latter, also the device name is appended.
         compilation_time (float): The time it took to compile the benchmark.
         compiled_qc (QuantumCircuit | None): The compiled quantum circuit. If compilation failed, None is returned.
-        device (str): The device used for compilation.
+        device (Device): The device used for compilation.
 
     """
 
@@ -25,10 +27,10 @@ class Result:
         compilation_setup: str,
         compilation_time: float,
         compiled_qc: QuantumCircuit | None,
-        device: str,
+        device: Device,
     ) -> None:
         if compiled_qc is not None:
-            rew_fid = reward.expected_fidelity(compiled_qc, device)
+            rew_fid = reward.expected_fidelity_on_device(compiled_qc, device)
             rew_crit_depth = reward.crit_depth(compiled_qc)
         else:
             rew_fid = -1.0

--- a/src/mqt/predictor/evaluation.py
+++ b/src/mqt/predictor/evaluation.py
@@ -19,6 +19,7 @@ from pytket.passes import (
 from pytket.placement import GraphPlacement
 from qiskit import QuantumCircuit, transpile
 
+from mqt.bench.devices import get_available_devices
 from mqt.bench.tket_helper import get_rebase
 from mqt.predictor import Result, ml, reward, rl
 
@@ -189,7 +190,7 @@ def evaluate_sample_circuit(filename: str) -> dict[str, Any]:
     results.update(create_mqtpredictor_result(qc, "expected_fidelity", filename=filename).get_dict())
     results.update(create_mqtpredictor_result(qc, "critical_depth", filename=filename).get_dict())
 
-    for _i, dev in enumerate(rl.helper.get_devices()):
+    for _i, dev in enumerate(get_available_devices()):
         results.update(create_qiskit_result(qc, dev).get_dict())
         results.update(create_tket_result(qc, dev).get_dict())
 

--- a/src/mqt/predictor/ml/Predictor.py
+++ b/src/mqt/predictor/ml/Predictor.py
@@ -11,6 +11,7 @@ from qiskit import QuantumCircuit
 from sklearn.ensemble import RandomForestClassifier
 from sklearn.model_selection import GridSearchCV, train_test_split
 
+from mqt.bench.devices import get_available_devices
 from mqt.predictor import ml, reward, rl, utils
 
 if TYPE_CHECKING:
@@ -86,7 +87,7 @@ class Predictor:
             if filename.suffix != ".qasm":
                 return
 
-            for i, dev in enumerate(rl.helper.get_devices()):
+            for i, dev in enumerate(get_available_devices()):
                 target_filename = str(filename).split("/")[-1].split(".qasm")[0] + "_" + figure_of_merit + "_" + str(i)
                 if (Path(target_path) / (target_filename + ".qasm")).exists() or qc.num_qubits > dev["max_qubits"]:
                     continue
@@ -127,7 +128,7 @@ class Predictor:
         rl_pred = rl.Predictor(figure_of_merit=figure_of_merit, device_name=device_name)
 
         dev_index = rl.helper.get_device_index_of_device(device_name)
-        dev_max_qubits = rl.helper.get_devices()[dev_index]["max_qubits"]
+        dev_max_qubits = get_available_devices()[dev_index]["max_qubits"]
 
         if source_path is None:
             source_path = ml.helper.get_path_training_circuits()
@@ -190,7 +191,7 @@ class Predictor:
                 device_name, timeout, figure_of_merit, source_path, target_path, logger.level
             )
             for figure_of_merit in ["expected_fidelity", "critical_depth"]
-            for device_name in [dev["name"] for dev in rl.helper.get_devices()]
+            for device_name in [dev["name"] for dev in get_available_devices()]
         )
 
     def generate_trainingdata_from_qasm_files(

--- a/src/mqt/predictor/ml/helper.py
+++ b/src/mqt/predictor/ml/helper.py
@@ -16,6 +16,7 @@ import numpy as np
 from joblib import dump
 from qiskit import QuantumCircuit
 
+from mqt.bench.devices import get_available_devices
 from mqt.bench.utils import calc_supermarq_features
 from mqt.predictor import ml, reward, rl
 
@@ -61,11 +62,11 @@ def predict_device_for_figure_of_merit(
     assert ml_predictor.clf is not None
     classes = ml_predictor.clf.classes_  # type: ignore[unreachable]
     predicted_device_index = classes[np.argsort(predicted_device_index_probs)[::-1]]
-    devices = rl.helper.get_devices()
+    devices = get_available_devices()
 
     for index in predicted_device_index:
-        if devices[index]["max_qubits"] >= qc.num_qubits:
-            return devices[index]["name"]
+        if devices[index].num_qubits >= qc.num_qubits:
+            return devices[index].name
     msg = "No suitable device found."
     raise ValueError(msg)
 
@@ -101,8 +102,8 @@ def get_path_training_circuits_compiled() -> Path:
 
 def get_index_to_device_LUT() -> dict[int, str]:
     """Returns a look-up table (LUT) that maps the index of a device to its name."""
-    devices = rl.helper.get_devices()
-    return {i: device["name"] for i, device in enumerate(devices)}
+    devices = get_available_devices()
+    return {i: device.name for i, device in enumerate(devices)}
 
 
 def get_openqasm_gates() -> list[str]:

--- a/src/mqt/predictor/rl/PredictorEnv.py
+++ b/src/mqt/predictor/rl/PredictorEnv.py
@@ -119,7 +119,7 @@ class PredictorEnv(Env):  # type: ignore[misc]
     def calculate_reward(self) -> Any:
         """Calculates and returns the reward for the current state."""
         if self.reward_function == "expected_fidelity":
-            return reward.expected_fidelity(self.state, self.device.name)
+            return reward.expected_fidelity_on_device(self.state, self.device)
         if self.reward_function == "critical_depth":
             return reward.crit_depth(self.state)
         error_msg = f"Reward function {self.reward_function} not supported."  # type: ignore[unreachable]

--- a/src/mqt/predictor/rl/PredictorEnv.py
+++ b/src/mqt/predictor/rl/PredictorEnv.py
@@ -15,6 +15,7 @@ from qiskit.transpiler import CouplingMap, PassManager
 from qiskit.transpiler.passes import CheckMap, GatesInBasis
 from qiskit.transpiler.runningpassmanager import TranspileLayout
 
+from mqt.bench.devices import get_device_by_name
 from mqt.predictor import reward, rl
 
 logger = logging.getLogger("mqt-predictor")
@@ -35,7 +36,7 @@ class PredictorEnv(Env):  # type: ignore[misc]
         self.actions_mapping_indices = []
         self.actions_opt_indices = []
         self.used_actions: list[str] = []
-        self.device = rl.helper.get_device(device_name)
+        self.device = get_device_by_name(device_name)
 
         index = 0
 

--- a/src/mqt/predictor/rl/helper.py
+++ b/src/mqt/predictor/rl/helper.py
@@ -5,6 +5,7 @@ import os
 import sys
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
+from warnings import warn
 
 import numpy as np
 import requests
@@ -55,6 +56,7 @@ from qiskit.transpiler.runningpassmanager import ConditionalController
 from sb3_contrib import MaskablePPO
 from tqdm import tqdm
 
+from mqt.bench.devices import get_available_devices
 from mqt.bench.qiskit_helper import get_native_gates
 from mqt.bench.utils import calc_supermarq_features, get_cmap_from_devicename
 from mqt.predictor import reward, rl
@@ -296,7 +298,12 @@ def get_action_terminate() -> dict[str, Any]:
 
 
 def get_devices() -> list[dict[str, Any]]:
-    """Returns a list of dictionaries containing information about the devices that are available."""
+    """DEPRECATED: Returns a list of dictionaries containing information about the devices that are available."""
+    warn(
+        "This function is deprecated. Please use mqt.bench.devices.get_available_devices instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
     return [
         {
             "name": "ibm_washington",
@@ -531,7 +538,7 @@ class PreProcessTKETRoutingAfterQiskitLayout:
 
 
 def get_device(device_name: str) -> dict[str, Any]:
-    """Returns the device with the given name.
+    """DEPRECATED: Returns the device with the given name.
 
     Args:
         device_name (str): The name of the device to be returned.
@@ -539,6 +546,11 @@ def get_device(device_name: str) -> dict[str, Any]:
     Returns:
         dict[str, Any]: The device with the given name.
     """
+    warn(
+        "This function is deprecated. Please use mqt.bench.devices.get_device_by_name instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
     devices = get_devices()
     for device in devices:
         if device["name"] == device_name:
@@ -557,9 +569,9 @@ def get_device_index_of_device(device_name: str) -> int:
     Returns:
         int: The index of the device with the given name.
     """
-    devices = get_devices()
+    devices = get_available_devices()
     for i, device in enumerate(devices):
-        if device["name"] == device_name:
+        if device.name == device_name:
             return i
 
     msg = "No suitable device found."

--- a/tests/device_selection/test_helper_ml.py
+++ b/tests/device_selection/test_helper_ml.py
@@ -1,20 +1,8 @@
 from __future__ import annotations
 
 from mqt.bench import benchmark_generator
+from mqt.bench.devices import get_available_device_names, get_available_devices
 from mqt.predictor import ml, qcompile
-
-
-def test_get_index_to_device_LUT() -> None:
-    expected = {
-        0: "ibm_washington",
-        1: "ibm_montreal",
-        2: "oqc_lucy",
-        3: "rigetti_aspen_m2",
-        4: "ionq_harmony",
-        5: "ionq_aria1",
-        6: "quantinuum_h2",
-    }
-    assert ml.helper.get_index_to_device_LUT() == expected
 
 
 def test_load_training_data() -> None:
@@ -54,15 +42,12 @@ def test_get_path_trained_model() -> None:
 
 def test_predict_device_for_figure_of_merit() -> None:
     qc = benchmark_generator.get_benchmark("ghz", 1, 5)
-    assert (
-        ml.helper.predict_device_for_figure_of_merit(qc, "expected_fidelity")
-        in ml.helper.get_index_to_device_LUT().values()
-    )
+    assert ml.helper.predict_device_for_figure_of_merit(qc, "expected_fidelity") in get_available_devices()
 
 
 def test_qcompile() -> None:
     qc = benchmark_generator.get_benchmark("ghz", 1, 5)
     qc_compiled, compilation_information, quantum_device = qcompile(qc)
-    assert quantum_device in ml.helper.get_index_to_device_LUT().values()
+    assert quantum_device in get_available_device_names()
     assert qc_compiled.layout is not None
     assert len(qc_compiled) > 0

--- a/tests/device_selection/test_predictor_ml.py
+++ b/tests/device_selection/test_predictor_ml.py
@@ -6,6 +6,7 @@ from typing import Final
 import numpy as np
 
 from mqt.bench import benchmark_generator
+from mqt.bench.devices import get_available_devices, get_device_by_name
 from mqt.predictor import ml, reward
 
 
@@ -21,10 +22,11 @@ def test_predict() -> None:
     assert predictor.clf is not None
     classes = predictor.clf.classes_  # type: ignore[unreachable]
     predicted_device_indices = classes[np.argsort(predictions)[::-1]]
-    assert all(0 <= i < len(ml.helper.get_index_to_device_LUT()) for i in predicted_device_indices)
+    devices = get_available_devices()
+    assert all(0 <= i < len(devices) for i in predicted_device_indices)
     predictions = predictor.predict_probs(qc.qasm(), figure_of_merit=figure_of_merit)
     predicted_device_indices = classes[np.argsort(predictions)[::-1]]
-    assert all(0 <= i < len(ml.helper.get_index_to_device_LUT()) for i in predicted_device_indices)
+    assert all(0 <= i < len(devices) for i in predicted_device_indices)
     Path(filename).unlink()
 
 
@@ -48,7 +50,7 @@ def test_compile_all_circuits_for_dev_and_fom() -> None:
     qasm_path = Path("test.qasm")
     qc.qasm(filename=str(qasm_path))
     predictor.compile_all_circuits_devicewise(
-        device_name="ionq_harmony",
+        device=get_device_by_name("ionq_harmony"),
         timeout=100,
         figure_of_merit=figure_of_merit,
         source_path=source_path,

--- a/tests/test_evaluation.py
+++ b/tests/test_evaluation.py
@@ -19,7 +19,7 @@ def test_evaluate_sample_circuit() -> None:
                 expected_keys.append(compilation_setup + "_" + key)
             else:
                 expected_keys.extend(
-                    [compilation_setup + "_" + device["name"] + "_" + key for device in get_available_devices()]
+                    [compilation_setup + "_" + device.name + "_" + key for device in get_available_devices()]
                 )
 
     assert all(key in res for key in expected_keys)

--- a/tests/test_evaluation.py
+++ b/tests/test_evaluation.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from pathlib import Path
 
 from mqt.bench import get_benchmark
-from mqt.predictor import rl
+from mqt.bench.devices import get_available_devices
 from mqt.predictor.evaluation import evaluate_sample_circuit
 
 
@@ -19,7 +19,7 @@ def test_evaluate_sample_circuit() -> None:
                 expected_keys.append(compilation_setup + "_" + key)
             else:
                 expected_keys.extend(
-                    [compilation_setup + "_" + device["name"] + "_" + key for device in rl.helper.get_devices()]
+                    [compilation_setup + "_" + device["name"] + "_" + key for device in get_available_devices()]
                 )
 
     assert all(key in res for key in expected_keys)


### PR DESCRIPTION
This PR integrates the new device module which is introduced in this [mqt-bench PR](https://github.com/cda-tum/mqt-bench/pull/272) and based on this [mqt-predictor PR](https://github.com/cda-tum/mqt-predictor/pull/71).

The main idea is to make use of a `Device` class which provides standardised attributes.
The `Device` class itself provides the data based on configuration files (in mqt-bench).