### PR TITLE
❇️ Add Layout Attribute and improved action space

### DIFF
--- a/src/mqt/predictor/rl/Predictor.py
+++ b/src/mqt/predictor/rl/Predictor.py
@@ -62,7 +62,6 @@ class Predictor:
             action_item = self.env.action_set[action]
             used_compilation_passes.append(action_item["name"])
             obs, reward_val, terminated, truncated, info = self.env.step(action)
-            self.env.state._layout = self.env.layout  # noqa: SLF001
 
         if not self.env.error_occured:
             return self.env.state, used_compilation_passes

--- a/src/mqt/predictor/rl/PredictorEnv.py
+++ b/src/mqt/predictor/rl/PredictorEnv.py
@@ -187,7 +187,7 @@ class PredictorEnv(Env):  # type: ignore[misc]
                     if action["name"] == "QiskitO3":
                         pm = PassManager()
                         pm.append(
-                            action["transpile_pass"](self.device["native_gates"], CouplingMap(self.device["cmap"])),
+                            action["transpile_pass"],
                             do_while=action["do_while"],
                         )
                     else:

--- a/src/mqt/predictor/rl/PredictorEnv.py
+++ b/src/mqt/predictor/rl/PredictorEnv.py
@@ -9,6 +9,7 @@ if TYPE_CHECKING:
 import numpy as np
 from gymnasium import Env
 from gymnasium.spaces import Box, Dict, Discrete
+from pytket.circuit import Qubit
 from pytket.extensions.qiskit import qiskit_to_tk, tk_to_qiskit
 from qiskit import QuantumCircuit
 from qiskit.transpiler import CouplingMap, PassManager
@@ -67,6 +68,7 @@ class PredictorEnv(Env):  # type: ignore[misc]
         self.action_space = Discrete(len(self.action_set.keys()))
         self.num_steps = 0
         self.layout = None
+        self.num_qubits_uncompiled_circuit = 0
 
         spaces = {
             "num_qubits": Discrete(128),
@@ -83,6 +85,7 @@ class PredictorEnv(Env):  # type: ignore[misc]
     def step(self, action: int) -> tuple[dict[str, Any], float, bool, bool, dict[Any, Any]]:
         """Executes the given action and returns the new state, the reward, whether the episode is done, whether the episode is truncated and additional information."""
         self.used_actions.append(str(self.action_set[action].get("name")))
+        print(self.action_set[action].get("name"), self.layout)
         altered_qc = self.apply_action(action)
         if not altered_qc:
             return (
@@ -112,6 +115,7 @@ class PredictorEnv(Env):  # type: ignore[misc]
         if self.state.count_ops().get("unitary"):
             self.state = self.state.decompose(gates_to_decompose="unitary")
 
+        self.state._layout = self.layout  # noqa: SLF001
         obs = rl.helper.create_feature_dict(self.state)
         return obs, reward_val, done, False, {}
 
@@ -161,6 +165,8 @@ class PredictorEnv(Env):  # type: ignore[misc]
         self.valid_actions = self.actions_opt_indices + self.actions_synthesis_indices
 
         self.error_occured = False
+
+        self.num_qubits_uncompiled_circuit = self.state.num_qubits
         return rl.helper.create_feature_dict(self.state), {}
 
     def action_masks(self) -> list[bool]:
@@ -208,14 +214,24 @@ class PredictorEnv(Env):  # type: ignore[misc]
                         initial_layout=pm.property_set["layout"],
                         input_qubit_mapping=pm.property_set["original_qubit_indices"],
                         final_layout=pm.property_set["final_layout"],
+                        _output_qubit_list=altered_qc.qubits,
+                        _input_qubit_count=self.num_qubits_uncompiled_circuit,
                     )
+                elif action_index in self.actions_routing_indices:
+                    self.layout.final_layout = pm.property_set["final_layout"]  # type: ignore[attr-defined]
 
             elif action["origin"] == "tket":
                 try:
-                    tket_qc = qiskit_to_tk(self.state)
+                    tket_qc = qiskit_to_tk(self.state, preserve_param_uuid=True)
                     for elem in transpile_pass:
                         elem.apply(tket_qc)
+                    qbs = tket_qc.qubits
+                    qubit_map = {qbs[i]: Qubit("q", i) for i in range(len(qbs))}
+                    tket_qc.rename_units(qubit_map)  # type: ignore[arg-type]
                     altered_qc = tk_to_qiskit(tket_qc)
+                    if action_index in self.actions_routing_indices:
+                        self.layout.final_layout = rl.helper.final_layout_pytket_to_qiskit(tket_qc)  # type: ignore[attr-defined]
+
                 except Exception:
                     logger.exception(
                         "Error in executing TKET transpile  pass for {action} at step {i} for {filename}".format(
@@ -251,8 +267,8 @@ class PredictorEnv(Env):  # type: ignore[misc]
         if mapped and self.layout is not None:
             return [self.action_terminate_index, *self.actions_opt_indices]  # type: ignore[unreachable]
 
-        if self.state._layout is not None:  # noqa: SLF001
-            return self.actions_routing_indices
+        if self.layout is not None:
+            return self.actions_routing_indices  # type: ignore[unreachable]
 
         # No layout applied yet
         return self.actions_mapping_indices + self.actions_layout_indices + self.actions_opt_indices

--- a/src/mqt/predictor/rl/helper.py
+++ b/src/mqt/predictor/rl/helper.py
@@ -168,23 +168,12 @@ def get_actions_opt() -> list[dict[str, Any]]:
         },
         {
             "name": "QiskitO3",
-            "transpile_pass": lambda bgates, cmap: [
+            "transpile_pass": [
                 Collect2qBlocks(),
-                ConsolidateBlocks(basis_gates=bgates),
-                UnitarySynthesis(basis_gates=bgates, coupling_map=cmap),
-                Optimize1qGatesDecomposition(basis=bgates),
-                CommutativeCancellation(basis_gates=bgates),
-                GatesInBasis(bgates),
-                ConditionalController(
-                    [
-                        pass_
-                        for x in common.generate_translation_passmanager(
-                            target=None, basis_gates=bgates, coupling_map=cmap
-                        ).passes()
-                        for pass_ in x["passes"]
-                    ],
-                    condition=lambda property_set: not property_set["all_gates_in_basis"],
-                ),
+                ConsolidateBlocks(),
+                UnitarySynthesis(),
+                Optimize1qGatesDecomposition(),
+                CommutativeCancellation(),
                 Depth(recurse=True),
                 FixedPoint("depth"),
                 Size(recurse=True),

--- a/src/mqt/predictor/rl/helper.py
+++ b/src/mqt/predictor/rl/helper.py
@@ -44,7 +44,6 @@ from qiskit.transpiler.passes import (
     OptimizeCliffords,
     RemoveDiagonalGatesBeforeMeasure,
     SabreLayout,
-    SabreSwap,
     Size,
     StochasticSwap,
     TrivialLayout,
@@ -70,16 +69,6 @@ else:
 
 
 logger = logging.getLogger("mqt-predictor")
-
-
-NUM_ACTIONS_OPT = 13
-NUM_ACTIONS_LAYOUT = 3
-NUM_ACTIONS_ROUTING = 4
-NUM_ACTIONS_SYNTHESIS = 1
-NUM_ACTIONS_TERMINATE = 1
-NUM_ACTIONS_DEVICES = 7
-NUM_ACTIONS_MAPPING = 1
-NUM_FEATURE_VECTOR_ELEMENTS = 7
 
 
 def qcompile(
@@ -231,16 +220,6 @@ def get_actions_layout() -> list[dict[str, Any]]:
             ],
             "origin": "qiskit",
         },
-        {
-            "name": "SabreLayout",
-            "transpile_pass": lambda c: [
-                SabreLayout(coupling_map=CouplingMap(c), skip_routing=True),
-                FullAncillaAllocation(coupling_map=CouplingMap(c)),
-                EnlargeWithAncilla(),
-                ApplyLayout(),
-            ],
-            "origin": "qiskit",
-        },
     ]
 
 
@@ -263,11 +242,6 @@ def get_actions_routing() -> list[dict[str, Any]]:
         {
             "name": "StochasticSwap",
             "transpile_pass": lambda c: [StochasticSwap(coupling_map=CouplingMap(c))],
-            "origin": "qiskit",
-        },
-        {
-            "name": "SabreSwap",
-            "transpile_pass": lambda c: [SabreSwap(coupling_map=CouplingMap(c))],
             "origin": "qiskit",
         },
     ]

--- a/tests/compilation/test_helper_rl.py
+++ b/tests/compilation/test_helper_rl.py
@@ -2,35 +2,14 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import numpy as np
 import pytest
 
 from mqt.bench import get_benchmark
 from mqt.predictor import rl
 
 
-def test_get_actions_opt() -> None:
-    assert len(rl.helper.get_actions_opt()) == rl.helper.NUM_ACTIONS_OPT
-
-
-def test_get_actions_layout() -> None:
-    assert len(rl.helper.get_actions_layout()) == rl.helper.NUM_ACTIONS_LAYOUT
-
-
-def test_et_actions_routing() -> None:
-    assert len(rl.helper.get_actions_routing()) == rl.helper.NUM_ACTIONS_ROUTING
-
-
-def test_get_actions_synthesis() -> None:
-    assert len(rl.helper.get_actions_synthesis()) == rl.helper.NUM_ACTIONS_SYNTHESIS
-
-
-def test_get_action_terminate() -> None:
-    assert len(rl.helper.get_action_terminate()) == rl.helper.NUM_ACTIONS_TERMINATE
-
-
-def test_get_actions_devices() -> None:
-    assert len(rl.helper.get_devices()) == rl.helper.NUM_ACTIONS_DEVICES
-
+def test_get_device_false_input() -> None:
     with pytest.raises(RuntimeError):
         rl.helper.get_device("false_input")
 
@@ -38,10 +17,6 @@ def test_get_actions_devices() -> None:
 def test_get_device_index_of_device_false_input() -> None:
     with pytest.raises(RuntimeError):
         rl.helper.get_device_index_of_device("false_input")
-
-
-def test_get_actions_mapping() -> None:
-    assert len(rl.helper.get_actions_mapping()) == rl.helper.NUM_ACTIONS_MAPPING
 
 
 @pytest.mark.parametrize(
@@ -55,8 +30,8 @@ def test_get_device(device: str) -> None:
 def test_create_feature_dict() -> None:
     qc = get_benchmark("dj", 1, 5)
     features = rl.helper.create_feature_dict(qc)
-    assert features
-    assert len(features) == rl.helper.NUM_FEATURE_VECTOR_ELEMENTS
+    for feature in features.values():
+        assert isinstance(feature, (np.ndarray, int))
 
 
 def test_get_path_trained_model() -> None:

--- a/tests/compilation/test_predictor_rl.py
+++ b/tests/compilation/test_predictor_rl.py
@@ -1,14 +1,10 @@
 from __future__ import annotations
 
-import os
-
 import pytest
 from qiskit import QuantumCircuit
 
 from mqt.bench import get_benchmark
 from mqt.predictor import reward, rl
-
-IN_GITHUB_ACTIONS = os.getenv("GITHUB_ACTIONS") == "true"
 
 
 @pytest.mark.parametrize(
@@ -28,10 +24,7 @@ def test_qcompile_with_pretrained_models(figure_of_merit: reward.figure_of_merit
 )
 def test_qcompile_with_newly_trained_models(figure_of_merit: reward.figure_of_merit) -> None:
     predictor = rl.Predictor(figure_of_merit=figure_of_merit, device_name="ionq_harmony")
-    predictor.train_model(
-        timesteps=100,
-        test=True,
-    )
+    predictor.train_model(timesteps=200, test=True)
 
     qc = get_benchmark("ghz", 1, 5)
     res = rl.qcompile(qc, figure_of_merit=figure_of_merit, device_name="ionq_harmony")
@@ -39,6 +32,7 @@ def test_qcompile_with_newly_trained_models(figure_of_merit: reward.figure_of_me
     qc_compiled, compilation_information = res
 
     assert isinstance(qc_compiled, QuantumCircuit)
+    assert qc_compiled.layout is not None
     assert compilation_information is not None
 
 


### PR DESCRIPTION
This PR
- makes sure, that always a valid `Qiskit.QuantumCircuit.layout` attribute is set after the compilation (even when it is compiled with non-qiskit compilation passes)
- removes unnecessary sabre layout and routing actions (mapping is still in there)
- improves the Qiskit O3 optimization action such that it does not synthesize and map automatically any more