### PR TITLE
🎨 changed BQSKit lower cap and added oqc to its supported gate sets

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
     "sb3_contrib>=2.0.0",
     "scikit-learn>=1.5.1",
     "tensorboard>=2.17.0",
-    "bqskit>=1.1.2",
+    "bqskit>=1.2.0",
     "numpy>=1.26; python_version >= '3.12'",
     "numpy>=1.24; python_version >= '3.11'",
     "numpy>=1.22",

--- a/src/mqt/predictor/rl/helper.py
+++ b/src/mqt/predictor/rl/helper.py
@@ -597,6 +597,7 @@ def get_bqskit_native_gates(device: Device) -> list[gates.Gate] | None:
         "ionq": [gates.RXXGate(), gates.RZGate(), gates.RYGate(), gates.RXGate()],
         "quantinuum": [gates.RZZGate(), gates.RZGate(), gates.RYGate(), gates.RXGate()],
         "iqm": [gates.U3Gate(), gates.CZGate()],
+        "oqc": [gates.RZGate(), gates.XGate(), gates.SXGate(), gates.ECRGate()],
     }
 
     if provider not in native_gatesets:


### PR DESCRIPTION
So far, there was no `ECR` gate support from BQSKit and, therefore, it was not possible to synthesize to the OQC gateset that comprises exactly that gate. This has changed with v1.2.