### PR TITLE
📌 numpy 2 support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
     "numpy>=1.26; python_version >= '3.12'",
     "numpy>=1.24; python_version >= '3.11'",
     "numpy>=1.22",
-    "numpy<2.0.0", # sb3/pytortch is currently not yet compatible https://github.com/DLR-RM/stable-baselines3/blob/9a3b28bb9f24a1646479500fb23be55ba652a30d/setup.py#L104
+    "numpy<2; sys_platform == 'darwin' and 'x86_64' in platform_machine",  # Restrict numpy v2 for macOS x86 since it is not supported anymore since torch v2.3.0
 ]
 
 classifiers = [


### PR DESCRIPTION
This PR ensures numpy v2 support for the MQT Predictor. 